### PR TITLE
Парсинг параметров запроса

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.3.1</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/src/main/java/ru/netology/Main.java
+++ b/src/main/java/ru/netology/Main.java
@@ -3,11 +3,13 @@ package ru.netology;
 import ru.netology.handlers.HandlerForClassic;
 import ru.netology.handlers.StandardHandler;
 
-public class Main {
+import java.net.URISyntaxException;
+
+public class Main  {
   public static final int PORT = 9999;
   public static final int THREADS = 64;
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws URISyntaxException {
     Server server = new Server(THREADS);
 
     // добавление хендлеров (обработчиков)

--- a/src/main/java/ru/netology/Request.java
+++ b/src/main/java/ru/netology/Request.java
@@ -19,6 +19,7 @@ public class Request {
         this.path = path.contains("?") ? path.substring(0, path.indexOf("?")) : path;
         this.version = version;
         queryParams = URLEncodedUtils.parse(new URI(path), StandardCharsets.UTF_8);
+        this.queryParams = URLEncodedUtils.parse(new URI(path), StandardCharsets.UTF_8);
     }
 
     public static Request parseRequest(String[] parts) throws URISyntaxException {
@@ -40,4 +41,17 @@ public class Request {
         return version;
     }
 
+    public List<NameValuePair> getQueryParams() {
+        return queryParams;
+    }
+
+    public String getQueryParam(String paramName) {
+        String paramValue = queryParams.stream()
+                            .filter(nameValuePair -> nameValuePair.getName().equals(paramName))
+                            .findFirst()
+                            .map(NameValuePair::getValue)
+                            .orElse(null);
+
+        return paramValue;
+    }
 }

--- a/src/main/java/ru/netology/Request.java
+++ b/src/main/java/ru/netology/Request.java
@@ -18,8 +18,11 @@ public class Request {
         this.method = method;
         this.path = path.contains("?") ? path.substring(0, path.indexOf("?")) : path;
         this.version = version;
-        queryParams = URLEncodedUtils.parse(new URI(path), StandardCharsets.UTF_8);
         this.queryParams = URLEncodedUtils.parse(new URI(path), StandardCharsets.UTF_8);
+        // Демонстрация функционала
+        System.out.println("path = " + this.path);
+        System.out.println("Список параметров: " + this.queryParams.toString());
+        System.out.println("Конкретный параметр (test): " + getQueryParam("test"));
     }
 
     public static Request parseRequest(String[] parts) throws URISyntaxException {

--- a/src/main/java/ru/netology/Request.java
+++ b/src/main/java/ru/netology/Request.java
@@ -1,17 +1,27 @@
 package ru.netology;
 
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URLEncodedUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 public class Request {
     private final String method;
     private final String path;
     private final String version;
+    private final List<NameValuePair> queryParams;
 
-    private Request(String method, String path, String version) {
+    private Request(String method, String path, String version) throws URISyntaxException {
         this.method = method;
-        this.path = path;
+        this.path = path.contains("?") ? path.substring(0, path.indexOf("?")) : path;
         this.version = version;
+        queryParams = URLEncodedUtils.parse(new URI(path), StandardCharsets.UTF_8);
     }
 
-    public static Request parseRequest(String[] parts) {
+    public static Request parseRequest(String[] parts) throws URISyntaxException {
         String method = parts[0];
         String path = parts[1];
         String version = parts[2];
@@ -22,7 +32,6 @@ public class Request {
         return method;
     }
 
-
     public String getPath() {
         return path;
     }
@@ -30,4 +39,5 @@ public class Request {
     public String getVersion() {
         return version;
     }
+
 }

--- a/src/main/java/ru/netology/Server.java
+++ b/src/main/java/ru/netology/Server.java
@@ -10,7 +10,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -26,7 +25,7 @@ public class Server {
         handlers = new ConcurrentHashMap<>();
     }
 
-    public void start(int port) throws URISyntaxException {
+    public void start(int port) {
         try (ServerSocket serverSocket = new ServerSocket(port)) {
             while (true) {
                 Socket clientSocket = serverSocket.accept();

--- a/src/main/java/ru/netology/Server.java
+++ b/src/main/java/ru/netology/Server.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,18 +26,24 @@ public class Server {
         handlers = new ConcurrentHashMap<>();
     }
 
-    public void start(int port) {
+    public void start(int port) throws URISyntaxException {
         try (ServerSocket serverSocket = new ServerSocket(port)) {
             while (true) {
                 Socket clientSocket = serverSocket.accept();
-                threadPool.submit(() -> connect(clientSocket));
+                threadPool.submit(() -> {
+                    try {
+                        connect(clientSocket);
+                    } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
             }
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
-    public void connect(Socket clientSocket) {
+    public void connect(Socket clientSocket) throws URISyntaxException {
         try (final BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
              final BufferedOutputStream out = new BufferedOutputStream(clientSocket.getOutputStream())) {
 


### PR DESCRIPTION
1. Добавлен парсинг параметров запроса при помощи утилиты org.apache.hc.core5.net.URLEncodedUtils
2. Теперь корректно отображаются страницы с параметрами (например: _http://localhost:999/index.html?test=777&p2=param_)